### PR TITLE
fix: support member access function calls (io.println)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,15 +6,14 @@ import { Typechecker } from "./src/typechecker"
 
 // error driven development right here
 const program = `
+
 use std/io
 
-extern fn puts(text: string) -> int
-
 pub fn main() {
-    puts("hi mum!!!!!!!")
+    io.println("hi")
+    io.puts("this too!")
     return 2
-}
-`.trim()
+}`.trim()
 
 const start = performance.now()
 
@@ -41,7 +40,7 @@ console.log(`resolved modules in ${(moduleTime - lexerTime).toFixed(3)}ms`)
 const astTime = performance.now()
 console.log(`parsed ${t.length} tokens in ${(astTime - moduleTime).toFixed(3)}ms, generated ${ast.body.length} root node(s)`)
 
-const tc = new Typechecker(ast);
+const tc = new Typechecker(ast, m);
 const c = tc.check()
 
 await Bun.write("tcAst.json", JSON.stringify(c, null, 2))

--- a/src/module/resolver.ts
+++ b/src/module/resolver.ts
@@ -1,15 +1,22 @@
-import { existsSync, readdirSync, readFileSync } from "fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
 import path from "path";
 import { Lexer } from "../lexer";
 import { Parser } from "../parser";
-import { Expression, FunctionDeclaration, ImportExpression, ProgramExpression } from "../parser/ast";
+import { Expression, FunctionDeclaration, ImportExpression, ProgramExpression, VariableDeclaration } from "../parser/ast";
 import { ResolvedModule } from "./types";
+
 export class ModuleResolver {
     private program: ProgramExpression;
     private modules: Map<string, ResolvedModule> = new Map();
+    private resolving: Set<string> = new Set(); // Track modules currently being resolved
+    private moduleSearchPaths: string[] = ["./src/module", "./node_modules", "./lib"];
+    private cache: Map<string, { content: string; mtime: number }> = new Map();
 
-    constructor(program: ProgramExpression) {
+    constructor(program: ProgramExpression, searchPaths?: string[]) {
         this.program = program;
+        if (searchPaths) {
+            this.moduleSearchPaths = [...searchPaths, ...this.moduleSearchPaths];
+        }
     }
 
     resolve() {

--- a/src/module/std/io/main.yt
+++ b/src/module/std/io/main.yt
@@ -1,5 +1,5 @@
 extern pub fn puts(text: string) -> int
 
-fn println(text: str) -> void {
+pub fn println(text: str) -> void {
     puts(text)
 }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -74,7 +74,7 @@ export type FunctionDeclaration = Expression & {
 
 export type FunctionCall = Expression & {
     type: "FunctionCall"
-    callee: Identifier// | MemberAccess
+    callee: Identifier | MemberAccess
     args: Expression[]
 }
 

--- a/src/typechecker/types.ts
+++ b/src/typechecker/types.ts
@@ -6,6 +6,7 @@ export type CheckerSymbol =
     | CheckerVariable
     | CheckerFunction
     | CheckerType
+    | CheckerModule
 
 export type CheckerVariable = {
     kind: "variable";
@@ -22,4 +23,10 @@ export type CheckerFunction = {
 export type CheckerType = {
     kind: "type";
     type: string
+}
+
+export type CheckerModule = {
+    kind: "module";
+    type: "module";
+    exports: Map<string, CheckerSymbol>;
 }


### PR DESCRIPTION
Add module namespace resolution to typechecker to handle function calls like io.println() from imported modules.